### PR TITLE
Update README to contain correct spelling of "Zweitag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ The fact that this repository is public has a few reasons:
 
 * In projects, you might inherit a config file from a central config file living here. It would be ugly to have something like authentication guarding the file
 * It is easier to access config files, for example for inheritance, from a CI pipeline
-* It can be used also for private purposes or by people not related to zweitag
+* It can be used also for private purposes or by people not related to Zweitag
 
 ## External contributions
-If you are not a member of zweitag you are of course free to use our configurations. But note that
+If you are not a member of Zweitag you are of course free to use our configurations. But note that
 
 * they might change
 *  we determined the rulesets in internal discussions and *might not be open for externally requested changes*
@@ -54,4 +54,4 @@ If you are not a member of zweitag you are of course free to use our configurati
 You may of course open issues or pull requests, but please don't be disappointed if they get rejected.
 
 ## Internal contributions
-If you are a member of zweitag feel free to open PRs and discuss certain decisions. If you think we reached a consensus (like, there are more people agreeing than actively disagreeing), please merge your PR.
+If you are a member of Zweitag feel free to open PRs and discuss certain decisions. If you think we reached a consensus (like, there are more people agreeing than actively disagreeing), please merge your PR.

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -16,7 +16,7 @@ which add additional rulesets concerned with the described topic.
 
 [The documentation](https://docs.rubocop.org/rubocop/index.html) is very good and explains each cop (and a lot more) in detail.
 
-# Our zweitag config
+# Our Zweitag config
 
 The commonly usable config file is located [here](rubocop/.rubocop.yml) in this repository.
 
@@ -29,7 +29,7 @@ It is based on some simple principles:
 1. **Exceptions should be added in a structured way**:
 (RuFo-) compatibilities and other justified exceptions in separate blocks. Inside of the blocks, sort the rules alphabetically and keep empty lines between namespaces to ease navigation.
 
-## Using the zweitag config
+## Using the Zweitag config
 
 Projects which are generated from our rails template repository should automatically use this config. If you want to use it in an existing project (please do), add the following lines to the top of your project specific `.rubocop.yml`:
 ```


### PR DESCRIPTION
Change lower case "zweitag" to "Zweitag" to reflect the brand standard