### PR TITLE
Discussion (RuboCop): Metric Cops

### DIFF
--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -5,6 +5,8 @@ require:
 AllCops:
   Exclude:
     - db/schema.rb # Let rails do its stuff
+    - db/migrate/{2015,2016,2017,2018,2019,2020}*.rb # do not enforce rule compliance on old migrations
+    - db/migrate/20210[1-6]*.rb # do not enforce rule compliance on old migrations
     - bin/**/* # Let gems do their stuff
     - vendor/bundle/**/* # Let gems do their stuff
     - .pryrc # Do what you want here
@@ -38,18 +40,9 @@ Style/WhileUntilDo:
 
 # Disable cops with reasons:
 
-Metrics/BlockLength:
-  Exclude:
-    - spec/**/* # describe or context blocks may be large
-    - config/**/* # There is no reason to artificially break up config blocks
-
 Rails/ApplicationRecord:
   Exclude:
     - db/migrate/* # You **should** mock models in migrations and use ActiveRecord::Base rather than ApplicationRecord!
-
-Metrics/MethodLength: 
-  Max: 20 # Accepting only methods of minimal length can hurt readability
-  CountAsOne: ['array', 'heredoc', 'hash'] #  Do not incentivies against multi-line and in-method constants and declarative programming
 
 Style/ClassAndModuleChildren: # Each version has its own benefits depending on the situation
   Enabled: false
@@ -63,4 +56,34 @@ Style/Lambda: # Always use `->` instead of `lambda`, as the latter does not work
   EnforcedStyle: literal
 Style/NumericPredicate: # Sometimes "== 0" is easier to read than .zero?
   Enabled: false
+###
+
+# Tune metrics cops
+
+# Background: metrics cops, although they are sometimes annoying, give you a stimulus to think about the complexity of the code.
+# So, while it is true that good code style is best ensured by peer review, pair programming or ensemble (mob) programming, it's
+# good that the metrics cops have your back and act as a last line of defense while you are wrapping your head around other
+# aspects. Therefore we soften the default limits, so that the cops are not too whiny and annouy the developers, but we keep them
+# enabled.
+# Recommendation: if you offend a metrics cop for good reason, disable that specific cop in the offending file only (see
+# https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code).
+
+Metrics/ClassLength:
+  Max: 200
+Metrics/ModuleLength:
+  Max: 200
+Metrics/MethodLength:
+  Max: 30
+  CountAsOne: ['array', 'heredoc', 'hash'] #  Do not incentivise against multi-line and in-method constants and declarative programming
+  Exclude:
+    - db/migrate/**/* # let migrations do what they need
+Metrics/BlockLength:
+  Exclude:
+    - config/**/* # There is no reason to artificially break up config blocks
+    - lib/tasks/**/*.rake
+    - spec/**/* # describe or context blocks may be large
+Metrics/ParameterLists:
+  Max: 3 # more than 3 positional arguments get confusing
+  CountKeywordArgs: false # keyword args are OK, they are way more readable than positional args
+
 ###

--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -64,7 +64,7 @@ Style/NumericPredicate: # Sometimes "== 0" is easier to read than .zero?
 # Background: metrics cops, although they are sometimes annoying, give you a stimulus to think about the complexity of the code.
 # So, while it is true that good code style is best ensured by peer review, pair programming or ensemble (mob) programming, it's
 # good that the metrics cops have your back and act as a last line of defense while you are wrapping your head around other
-# aspects. Therefore we soften the default limits, so that the cops are not too whiny and annouy the developers, but we keep them
+# aspects. Therefore we soften the default limits, so that the cops are not too whiny and annoy the developers, but we keep them
 # enabled.
 # Recommendation: if you offend a metrics cop for good reason, disable that specific cop in the offending file only (see
 # https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code). See also the README next to this file.

--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -47,6 +47,10 @@ Rails/ApplicationRecord:
   Exclude:
     - db/migrate/* # You **should** mock models in migrations and use ActiveRecord::Base rather than ApplicationRecord!
 
+Metrics/MethodLength: 
+  Max: 20 # Accepting only methods of minimal length can hurt readability
+  CountAsOne: ['array', 'heredoc', 'hash'] #  Do not incentivies against multi-line and in-method constants and declarative programming
+
 Style/ClassAndModuleChildren: # Each version has its own benefits depending on the situation
   Enabled: false
 Style/Documentation: # We currently do not enforce documentation. Do it where you feel it is useful!

--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -67,8 +67,9 @@ Style/NumericPredicate: # Sometimes "== 0" is easier to read than .zero?
 # aspects. Therefore we soften the default limits, so that the cops are not too whiny and annouy the developers, but we keep them
 # enabled.
 # Recommendation: if you offend a metrics cop for good reason, disable that specific cop in the offending file only (see
-# https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code).
+# https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code). See also the README next to this file.
 
+# Length metrics
 Metrics/ClassLength:
   Max: 200 # 2 times of the default value of 100, above this you should really think about splitting up the class
 Metrics/ModuleLength:
@@ -83,9 +84,13 @@ Metrics/BlockLength: # the default value of 25 is good
     - config/**/* # There is no reason to artificially break up config blocks
     - lib/tasks/**/*.rake
     - spec/**/* # describe or context blocks may be large
+
+# Method signature complexity metrics
 Metrics/ParameterLists:
   Max: 3 # more than 3 positional parameters get confusing, use keyword args or group input parameters in value objects instead
   CountKeywordArgs: false # keyword args are OK, they are way more readable than positional args
+
+# Code complexity metrics
 Metrics/AbcSize:
   Max: 43 # ~2.5 times of the default value of 17, above this your method is most likely too complex
 Metrics/CyclomaticComplexity:

--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -56,6 +56,7 @@ Style/Lambda: # Always use `->` instead of `lambda`, as the latter does not work
   EnforcedStyle: literal
 Style/NumericPredicate: # Sometimes "== 0" is easier to read than .zero?
   Enabled: false
+
 ###
 
 # Tune metrics cops
@@ -69,21 +70,27 @@ Style/NumericPredicate: # Sometimes "== 0" is easier to read than .zero?
 # https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code).
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 200 # 2 times of the default value of 100, above this you should really think about splitting up the class
 Metrics/ModuleLength:
-  Max: 200
+  Max: 200 # 2 times of the default value of 100, above this you should really think about splitting up the module
 Metrics/MethodLength:
-  Max: 30
+  Max: 30 # 3 times of the default value of 10, above this you should really think about splitting up the method
   CountAsOne: ['array', 'heredoc', 'hash'] #  Do not incentivise against multi-line and in-method constants and declarative programming
   Exclude:
     - db/migrate/**/* # let migrations do what they need
-Metrics/BlockLength:
+Metrics/BlockLength: # the default value of 25 is good
   Exclude:
     - config/**/* # There is no reason to artificially break up config blocks
     - lib/tasks/**/*.rake
     - spec/**/* # describe or context blocks may be large
 Metrics/ParameterLists:
-  Max: 3 # more than 3 positional arguments get confusing
+  Max: 3 # more than 3 positional parameters get confusing, use keyword args or group input parameters in value objects instead
   CountKeywordArgs: false # keyword args are OK, they are way more readable than positional args
+Metrics/AbcSize:
+  Max: 43 # ~2.5 times of the default value of 17, above this your method is most likely too complex
+Metrics/CyclomaticComplexity:
+  Max: 14 # 2 times of the default value of 7, above this your method is most likely too complex
+Metrics/PerceivedComplexity:
+  Max: 12 # 1.5 times of the default value of 8, above this your method is most likely too complex
 
 ###

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -45,7 +45,7 @@ Since the remote file will be cached locally you can still run rubocop offline. 
 ```
 to your project's `.gitignore`.
 
-### Overwriting rules specifically for your project
+## Overwriting rules specifically for your project
 
 Rubocop will use all rules from our shared config and override with rules set in config files imported later or directly written into your project's `.rubocop.yml`. More details on inheritance can be found in the
 [rubocop documentation](https://docs.rubocop.org/rubocop/configuration.html#inheritance).

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -79,7 +79,7 @@ The Rubocop default values for Metrics cops are tuned rather low. This will lead
 
 ### Disabling a cop for a specific offense
 
-If you offend a metrics cop for good reason, disable that specific cop in the offending file only, either for the specific location only, or for the whole file, [by adding a special rubocop:disable comment](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code).
+If you offend a metrics cop for good reason, disable that specific cop in the offending file only, either for the specific location only, or for the whole file, [by adding a special rubocop:disable comment](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code). Tip: use `rubocop:disable` when you want to disable the cop permanently, and use `rubocop:todo` when you want to disable the cop temporarily and plan to fix the offense later.
 
 ## Migrating an existing project
 

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -81,7 +81,7 @@ The Rubocop default values for Metrics cops are tuned rather low. This will lead
 
 If you offend a metrics cop for good reason, disable that specific cop in the offending file only, either for the specific location only, or for the whole file, [by adding a special rubocop:disable comment](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code).
 
-## How do I migrate an existing project?
+## Migrating an existing project
 
 After following the instructions above you will most likely have lots of offenses against the new rules. Do not despair! Rubocop has a solution for this:
 [Automatically generated ToDo configs](https://docs.rubocop.org/rubocop/configuration.html#automatically-generated-configuration).
@@ -96,7 +96,7 @@ To tick off your todo list, just remove an exception from the rubocop_todo confi
 You might want to fix the offenses in multiple PRs to make them easier to review and revert.
 
 This way you should either get rid of all exceptions or come to the conclusion that a cop does not fit our needs and that an exception should be added to the shared config here.
-If you find that a rule is sensible but you also think a violation is justified at some point you can [disable rules in your code by a comment](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code) (even inline comments since newer rubocop version).
+If you find that a rule is sensible but you also think an offense is justified at some point you can [disable rules in your code by a comment](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code) (even inline comments since newer rubocop version).
 
 # Adjusting the central config
 

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -69,6 +69,18 @@ Since rules can be overwritten you can still have project specific settings and 
 
 Ideally your .rubocop.yml should always be empty, except the inheritance statement.
 
+## Dealing with Metrics cops offenses
+
+### Why we enabled the Metrics cops
+
+We enabled cops from the [Metrics](https://docs.rubocop.org/rubocop/cops.html#metrics) department. They are based on some numerical measure about the source code. As such, they are much "softer" than other cops. Any `Max` limit that we configure will be wrong in a sense, and any offense might lead to discussions ("Why is this method with an ABC size metric value of 43 OK, and this other method with a value of 44 not? Why is the limit exactly 43?").
+
+The Rubocop default values for Metrics cops are tuned rather low. This will lead to many offenses, many discussions, and eventually in developers turning them off altogether. We propose to view the Metrics cops differently: as a _last line of defense_. Good code comes from peer review, pair programming, talking about good code and being conscious about it. But it is helpful that the cops have your back when you are wrapping your head around other aspects. Therefore, we tuned the Metrics cops limits to be much higher than the Rubocop defaults, by factor 1.5 to 3.
+
+### Disabling a cop for a specific offense
+
+If you offend a metrics cop for good reason, disable that specific cop in the offending file only, either for the specific location only, or for the whole file, [by adding a special rubocop:disable comment](https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code).
+
 ## How do I migrate an existing project?
 
 After following the instructions above you will most likely have lots of offenses against the new rules. Do not despair! Rubocop has a solution for this:

--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -74,7 +74,7 @@ Ideally your .rubocop.yml should always be empty, except the inheritance stateme
 After following the instructions above you will most likely have lots of offenses against the new rules. Do not despair! Rubocop has a solution for this:
 [Automatically generated ToDo configs](https://docs.rubocop.org/rubocop/configuration.html#automatically-generated-configuration).
 
-By running `rubocop --auto-gen-config`, rubocop generates a new file `.rubocop_todo.yml` where all rules are disabled which your code currently violates. ***Note**: You might have to adjust your `.rubocop.yml` file because the todo.yml gets added automatically as an inheritence which sometimes crashes with manually added ancestor files like our shared config!*
+By running `rubocop --auto-gen-config`, rubocop generates a new file `.rubocop_todo.yml` where all rules are disabled which your code currently violates. ***Note**: You might have to adjust your `.rubocop.yml` file because the todo.yml gets added automatically as an inheritance which sometimes crashes with manually added ancestor files like our shared config!*
 
 You can check this file in and postpone resolving the conflicts one by one when there is time, budget and patience.
 


### PR DESCRIPTION
I wanted to use this PR to discuss the (de-)activation of [RuboCop's Metric-Cops](https://docs.rubocop.org/rubocop/cops_metrics.html):

- Metrics/AbcSize
- Metrics/BlockNesting
- Metrics/ClassLength 
- Metrics/ModuleLength
- Metrics/CyclomaticComplexity
- Metrics/ParameterLists
- Metrics/PerceivedComplexity
- Metrics/MethodLength
- [Layout/LineLength](https://docs.rubocop.org/rubocop/1.3/cops_layout.html#layoutlinelength)

Initially there are a few points regarding code metrics in general:
1. Naturally these metrics only provide a heuristic for code complexity and readability. This is of course - in some way - true for many style decisions. But the question, where the right limit for most method's length should be, can not be argued for in the same way as we do argue about the use of a number literal.
2. Metric-Cops generally try to incentivize smaller logical units of programming. That in itself does not have to be argued about: if you can solve something in 3 smaller lines of code instead of 5 lines of code - all else being equal - you should aim for the smaller program. __But__ the phrase "all else being equal" has to lift a lot in that sentence for it to be true. Writing smaller programs are good because (and only if) they are easier to read and understand. Nobody wants programs looking like it is trying to win a [stack overflow code golf challenge](https://codegolf.stackexchange.com/questions/6043/were-no-strangers-to-code-golf-you-know-the-rules-and-so-do-i).
This does not have to be discussed. We can reasonably assume that there are limits to all metrics that allow writing sensible programs without counting single bytes.
3. The question I would like to discuss instead is, whether the metric cops in RuboCop mostly incentivize a sensible split up of too-large units of code or whether they mostly complain about code that has a good enough reason to be this long. Whether or not a unit of code - whether it's a class, module or method - should be split up is not entirely a question of length but rather of readability and logical coherence. Regarding the latter criteria there is one prominent rule - the [single responsibility principle](https://en.wikipedia.org/wiki/Single-responsibility_principle): each unit of code should solve one problem/undertake a single task.

I find this difficult to decide myself and will only share some observations here for now. These points and the discussion here of course are special to our use case of _Ruby_ on _Rails_ Applications:
1. In my own experience, complaints from these Metric Cops have rarely inspired improvements of readability or code structuring. They targeted code that was readable and structured correctly and did not try to solve too many tasks. This of course is a highly subjective experience but is one central motivation for opening this discussion. I will try to guess some of the reasons for this fact in the next observation. But of course it might still be a simple sign of habit I have to work on and not a reason against these metrics.
2. In rails applications, many units of code already have a single responsibility assigned too them through the patterns used. Controllers control requests regarding a single (sub)type of resource in a specific scope (e.g. API requests for the admin pages or web requests for user pages or search requests or ...).
Complex subtasks in these controllers or in models or in views can and should be extracted to specific Helper- and Job-classes. The same is true for rspec specs that test a single module and should extract complex test logic into support modules. 
Regardless of these extractions, a) models, b) controllers and c) specs still will increase in size with a) the amount of data the model should hold and the number of relationships they can have, b) the different types of interactions supported by the resource in this scope as well as the size of the model controlled and c) the size of the unit under test (which increases because of a) and b)).
When a unit reaches the metric limits because of these effects splitting them up - e.g. by introducing singularily used concerns - is in my humble opinion artificial and often hurts consistency and readability of the code. A controller composed out of many but small and simple actions and filters is readable and understandable and does not need to be changed. Neither does a model class that is consisting out of many declarations, simple accessors and validations.
3. The metric cops can not understand whether a unit of code is large in size because it solves complex subtasks that should be extracted or because it describes a large concept consisting out of many small subtasks coherently grouped by the unit. This decision can only be made by a human checking the code. Which is in my experience very successfully done in our QA process. The pattern or principle `Complex subtasks should get their own unit of code.` (which mostly means their own module or class) is a valuable one that we have integrated into our code culture but which can not be enforced or incentivized for by these cops. This might also be the reason for my next observation.
4. Most (if not all) projects at zweitag have had these cops (or most of them) deactivated in their config which would either change by using this central config or mean that we duplicate the deactivation to our project specific configs. Of course this repo does not only aim to provide code styles for zweitag projects but this is surely still the one main goal. Maybe it was a coincidence that I did not work on projects where these cops have been in use?

To be clear: even though I mostly mention classes, modules and test suites I hold the same principle true for smaller units of code, i.e. methods and even lines: the right amount of logic contained in those units is not (accurately) determined by their length but by the principle of the minimizing the amount of tasks per unit. Splitting up lines or methods because of their size can in my opinion often hurt their consistency and the readability of the parent unit. This is why - as a first concrete suggestion - I changed the configuration of the `MethodLength` Cop to avoid wrong incentives.

My personal suggestion based on these observations would clearly be to deactivate these cops or most of them and trust our QA in this regard. But I am only starting this discussion and would be glad to hear your point of views.