### PR TITLE
Disable rubocop quoted symbols rule

### DIFF
--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -17,6 +17,8 @@ AllCops:
 Layout:
   Enabled: false
 
+Style/QuotedSymbols:
+  Enabled: false
 Style/Semicolon:
   Enabled: false
 Style/StringLiterals:


### PR DESCRIPTION
Example:

```
spec/requests/api/v1/orders_controller_spec.rb:7:32: C: [Correctable] Style/QuotedSymbols: Prefer single-quoted symbols when you don't need string interpolation or special symbols.
  let(:app_version_header) { { "App-Version": app_version } }
```

However, rufo already ensures that we use double quotes everywhere, so this rule conflicts (like some other Style-rules).